### PR TITLE
Add support for Minecraft 1.20.1

### DIFF
--- a/.github/workflows/build-and-release-1.20.1.yml
+++ b/.github/workflows/build-and-release-1.20.1.yml
@@ -29,7 +29,8 @@ jobs:
       id: get_version
       run: |
         TAG_NAME=${GITHUB_REF#refs/tags/}
-        echo "VERSION=${TAG_NAME#1.20.1-v}" >> $GITHUB_OUTPUT
+        VERSION=${TAG_NAME#1.20.1-v}
+        echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
 
     - name: Create Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-and-release-1.20.1.yml
+++ b/.github/workflows/build-and-release-1.20.1.yml
@@ -22,6 +22,9 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
 
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
     - name: Build with Gradle
       run: ./gradlew build
 


### PR DESCRIPTION
This PR adds support for Minecraft 1.20.1 version with:
- Dedicated branch for 1.20.1
- GitHub Actions workflow for building and releasing 1.20.1 versions
- Proper Java 17 and dependency versions for 1.20.1

Related to issue #13

## Sourcery 总结

通过更新 Java 和依赖项、引入专用分支以及添加修正了版本提取逻辑的 GitHub Actions 构建和发布工作流，增加了对 Minecraft 1.20.1 的支持。

新功能：
- 添加对 Minecraft 1.20.1 的支持

错误修复：
- 修复构建和发布工作流中的版本提取逻辑

改进：
- 更新到 Java 17 并升级依赖项以兼容 Minecraft 1.20.1
- 引入用于 Minecraft 1.20.1 开发的专用分支

CI：
- 添加用于构建和发布 Minecraft 1.20.1 的 GitHub Actions 工作流

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Minecraft 1.20.1 by updating Java and dependencies, introducing a dedicated branch, and adding a GitHub Actions build-and-release workflow with corrected version extraction.

New Features:
- Add support for Minecraft 1.20.1

Bug Fixes:
- Fix version extraction logic in the build-and-release workflow

Enhancements:
- Update to Java 17 and bump dependencies for Minecraft 1.20.1 compatibility
- Introduce a dedicated branch for Minecraft 1.20.1 development

CI:
- Add GitHub Actions workflow for building and releasing Minecraft 1.20.1

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to more reliably derive version information during build and release, improving consistency of release names and tags.
  * Enhances CI stability with clearer version handling while keeping downstream release steps unchanged.
  * No changes to application features or behavior; end-users will simply see consistent versioning on published releases and assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->